### PR TITLE
Add chat_history ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Chat history
+chat_history/


### PR DESCRIPTION
## Summary
- avoid checking `chat_history` into source control by adding it to `.gitignore`

## Testing
- `python -m py_compile cli.py`

------
https://chatgpt.com/codex/tasks/task_e_6860784b57d08329bfa8cbe9d7c5e645