### PR TITLE
Organize history directories and add sorting tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 GroqChat is a minimal command-line chat interface for Groq's language model. The script stores chat history locally so you can resume conversations at any time.
 
+Chat history is kept in the `chat_history/` folder with two subdirectories:
+* `autosave/`  – files automatically created while chatting
+* `userchat/` – chats you explicitly save with `/save`
+
+Run `python cli.py sort` to create these folders and organise any existing files.
+
 ## Usage
 
 1. **Set your API key**


### PR DESCRIPTION
## Summary
- organize chat history into `autosave` and `userchat`
- ensure directories exist on start
- allow printing full history when loading
- add `sort` command (`python cli.py sort`) to arrange files
- document folder structure and sorting in README

## Testing
- `python -m py_compile cli.py`
- `python cli.py sort`

------
https://chatgpt.com/codex/tasks/task_e_68609ce4b7308329b5096a0160822542