### PR TITLE
Implement interactive chat browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,10 @@ Run `python cli.py sort` to create these folders and organise any existing files
    python cli.py
    ```
 
+### Commands
+
+- `/new` start a new chat session
+- `/save <name>` save the current chat
+- `/load <name>` load a saved chat
+- `/chats` browse chat history in a terminal interface
+


### PR DESCRIPTION
## Summary
- add `/chats` command to open a curses-based browser
- list chats sorted by modification time
- update welcome message and README with new command

## Testing
- `python -m py_compile cli.py`

------
https://chatgpt.com/codex/tasks/task_e_6860a62851048329971383f2fab70dc9