### PR TITLE
Improve /chats browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,5 +39,5 @@ Run `python cli.py sort` to create these folders and organise any existing files
 - `/new` start a new chat session
 - `/save <name>` save the current chat
 - `/load <name>` load a saved chat
-- `/chats` browse chat history in a terminal interface
+- `/chats` browse chat history starting with a list of subdirectories
 


### PR DESCRIPTION
## Summary
- update `/chats` to first list subdirectories before showing chat files
- document updated browsing workflow in README

## Testing
- `python -m py_compile cli.py`
- `python cli.py sort`

------
https://chatgpt.com/codex/tasks/task_e_6860a79cc3d08329aa66c61f5a32ed3c