### PR TITLE
Add custom prompts and chat summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,8 @@ Run `python cli.py sort` to create these folders and organise any existing files
 - `/save <name>` save the current chat
 - `/load <name>` load a saved chat
 - `/chats` browse chat history starting with a list of subdirectories
+- `/prompt new <name>` create a reusable prompt
+- `/prompt use <name>` send a saved prompt as your message
+- `/prompt list` list saved prompts
+- `/summary` generate a summary of the current conversation
 


### PR DESCRIPTION
## Summary
- allow saving and using reusable prompts via `/prompt`
- implement `/summary` to get a quick recap
- document the new commands

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile cli.py`

------
https://chatgpt.com/codex/tasks/task_e_6860aa3481fc832986fbc0c6a81674ae