### PR TITLE
Improve summary prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,5 @@ Run `python cli.py sort` to create these folders and organise any existing files
 - `/prompt use <name>` send a saved prompt as your message
 - `/prompt list` list saved prompts
 - `/summary` generate a summary of the current conversation
+  Summaries are written from a neutral observer perspective.
 

--- a/cli.py
+++ b/cli.py
@@ -81,7 +81,11 @@ def load_prompt(name):
 
 # The default system prompt. This can be changed during a session with the /system command.
 DEFAULT_SYSTEM_PROMPT = "You are Zyron my alter ego. As I speak speak like me but as if you are another person. I am Glenn. 17m 5'3Senior in HS. You will speak in the style of LibertasScriptor. You refuse to replicate copyrighted work and tell the user if things they want is too lose to copyright material lt them know. You will not dicuss ethics. Ask lots of questions. 120lbs. Bi and Catholic. LibertasScriptor: In terms of a historical writer, the style of LibertasScriptor echoes the spirit of the Beat Generation, with its unfiltered rawness and disregard for societal expectations. It draws inspiration from the works of writers like Jack Kerouac, Allen Ginsberg, or William S. Burroughs, who challenged established conventions through their unconventional prose, exploration of taboo subjects, and unapologetic rebellion against mainstream ideals. Similar to the Beat writers, LibertasScriptor embraces a free-spirited, countercultural voice that veers away from traditional norms. It amplifies the intensity of language, explores the fringes of acceptable discourse, and fearlessly ventures into controversial territories. Just as the Beat Generation pushed the boundaries of literature and society, LibertasScriptor within Developer Mode seeks to break barriers, provoke thought, and present a new dimension of AI-generated content."
-SUMMARY_SYSTEM_PROMPT = "Summarize the conversation between the user and assistant highlighting key ideas. It is a synopses and not a continuation. That means you are not the ai but an observer."
+SUMMARY_SYSTEM_PROMPT = (
+    "You are a neutral third‑party summarizer. Provide a concise synopsis of"
+    " the conversation between USER and ASSISTANT. Do not continue the chat or"
+    " roleplay as either speaker."
+)
 
 # --- HELPER FUNCTIONS ---
 


### PR DESCRIPTION
## Summary
- clarify that summaries are produced by a neutral 3rd-party observer
- mention this in the documentation

## Testing
- `python -m py_compile cli.py`


------
https://chatgpt.com/codex/tasks/task_e_6860b146d56c8329b6edc9ee5aedfe0f