### PR TITLE
Add chat metadata and conversion utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Chat history is kept in the `chat_history/` folder with two subdirectories:
 * `userchat/` – chats you explicitly save with `/save`
 
 Run `python cli.py sort` to create these folders and organise any existing files.
+Run `python cli.py convert` to update old `.chat` files to version 1.0.
 
 ## Usage
 
@@ -42,10 +43,12 @@ Run `python cli.py sort` to create these folders and organise any existing files
 - `/chats` browse chat history starting with a list of subdirectories
 - `/prompt new <name>` create a reusable prompt
 - `/prompt use <name>` send a saved prompt as your message
+- `/prompt sys <name>` set the system prompt from a saved prompt
 - `/prompt list` list saved prompts
 - `/summary` generate a summary of the current conversation
 
 The chat interface automatically trims context to the most recent 10
 messages. The system prompt is always included when sending requests to
-the model.
+the model. Chat history files now store metadata such as the chat name,
+model and format version in addition to the message list.
 


### PR DESCRIPTION
## Summary
- add metadata support to `.chat` files and auto-generate chat names
- allow system prompts to load saved prompts
- update chat browsing and messages to show chat name
- add `convert` command to upgrade old chat files
- document new behaviour in README

## Testing
- `python -m py_compile cli.py`

------
https://chatgpt.com/codex/tasks/task_e_68615812f46483298bc545b2771009a9