### PR TITLE
Improve mobile UI

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1,6 +1,16 @@
 let chatData={};
 let currentTab='';
 
+function toggleSidebar(){
+  document.getElementById('sidebar').classList.toggle('show');
+}
+
+function hideSidebarOnMobile(){
+  if(window.innerWidth<=700){
+    document.getElementById('sidebar').classList.remove('show');
+  }
+}
+
 function md(t){
   let h=t.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
   h=h.replace(/\*\*(.+?)\*\*/g,'<strong>$1</strong>');
@@ -75,6 +85,7 @@ async function loadChat(name){
   const res=await fetch('/api/load',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({filename:name})});
   const data=await res.json();
   showMessages(data.chat,data.result);
+  hideSidebarOnMobile();
 }
 
 async function updateSystem(){
@@ -90,6 +101,7 @@ async function sendMsg(){
   const res=await fetch('/api/message',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({message:text})});
   const data=await res.json();
   showMessages(data.chat,data.result);
+  hideSidebarOnMobile();
 }
 
 async function archiveFile(name){

--- a/static/index.html
+++ b/static/index.html
@@ -4,8 +4,10 @@
   <meta charset='utf-8'>
   <title>GroqChat Web</title>
   <style>
-    body{font-family:Arial,Helvetica,sans-serif;margin:0;display:flex;height:100vh;background:#1e1e1e;color:#eee}
+    body{font-family:Arial,Helvetica,sans-serif;margin:0;display:flex;height:100vh;background:#1e1e1e;color:#eee;font-size:16px}
     #sidebar{width:250px;border-right:1px solid #444;overflow-y:auto;padding:10px;background:#2b2b2b;display:flex;flex-direction:column}
+    #sidebar.show{transform:translateX(0)}
+    #menuButton{display:none;position:fixed;top:10px;left:10px;z-index:11;background:#444;color:#eee;border:1px solid #555;font-size:20px;padding:5px 10px;cursor:pointer}
     #tabButtons{display:flex;margin-bottom:10px}
     .tab{flex:1;padding:5px;background:#333;border:1px solid #444;color:#eee;cursor:pointer;text-align:center}
     .tab.active{background:#555}
@@ -48,13 +50,18 @@
     }
 
     @media (max-width: 700px) {
-      body{flex-direction:column}
-      #sidebar{width:100%;height:200px;border-right:none;border-bottom:1px solid #444}
-      #chat{flex:1}
+      body{flex-direction:column;font-size:18px}
+      #sidebar{position:fixed;top:0;left:0;height:100vh;width:250px;border-bottom:none;transform:translateX(-260px);transition:transform .3s;z-index:10}
+      #chat{flex:1;margin-left:0}
+      #menuButton{display:block}
+      .chat-name{font-size:16px}
+      .chat-file{font-size:14px}
+      #chatName{font-size:20px}
     }
   </style>
 </head>
 <body>
+  <button id='menuButton' onclick='toggleSidebar()'>☰</button>
   <div id='sidebar'>
     <h3>Chats</h3>
     <div id='tabButtons'></div>


### PR DESCRIPTION
## Summary
- adjust layout and font sizing for small screens
- add hamburger button to toggle sidebar on mobile
- hide sidebar after selecting chat or sending message

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6862d76588f88329a1559ba5c639bb0a