### PR TITLE
Add archive cleanup and summary improvements

### DIFF
--- a/logic.py
+++ b/logic.py
@@ -71,6 +71,7 @@ def get_new_session_state():
         "version": CHAT_VERSION,
         "model": MODEL,
         "messages": [{"role": "system", "content": load_default_prompt()}],
+        "summary": "",
     }
     return chat_data, autosave_filename
 
@@ -126,11 +127,13 @@ def load_chat_from_file(filename):
             "version": "0",
             "model": MODEL,
             "messages": data,
+            "summary": "",
         }
     elif isinstance(data, dict) and "messages" in data:
         data.setdefault("name", os.path.splitext(os.path.basename(filepath))[0])
         data.setdefault("model", MODEL)
         data.setdefault("version", CHAT_VERSION)
+        data.setdefault("summary", "")
         chat_data = data
     else:
         return None, None

--- a/static/app.js
+++ b/static/app.js
@@ -48,6 +48,7 @@ function renderTabs(order){
 function renderFiles(){
   const list=document.getElementById('fileList');
   list.innerHTML='';
+  document.getElementById('clearArchiveBtn').style.display=currentTab==='archive'?'':'none';
   if(!currentTab) return;
   chatData[currentTab].forEach(item=>{
     const div=document.createElement('div');
@@ -120,12 +121,19 @@ async function deleteFile(name){
   loadChats();
 }
 
+async function clearArchive(){
+  if(!confirm('Delete all archived chats?')) return;
+  await fetch('/api/clear-archive',{method:'POST'});
+  loadChats();
+}
+
 function showMessages(chat,res){
   const msgs=chat.messages;
   document.getElementById('chatName').textContent=chat.name||'';
   document.getElementById('chatPath').textContent=chat.file||'';
   const div=document.getElementById('messages');
   div.innerHTML='';
+  document.getElementById('summaryText').textContent=chat.summary||'';
   if(msgs[0]&&msgs[0].role==='system') setSystem(msgs[0].content);
   msgs.slice(1).forEach(m=>{
     const p=document.createElement('div');
@@ -171,8 +179,11 @@ function showMessages(chat,res){
       div.appendChild(p);
     }
     if(res.summary){
-      document.getElementById('summaryBox').textContent=res.summary;
+      document.getElementById('summaryText').textContent=res.summary;
     }
+  }
+  if(chat.summary){
+    document.getElementById('summaryText').textContent=chat.summary;
   }
   loadChats();
 }

--- a/static/index.html
+++ b/static/index.html
@@ -22,7 +22,8 @@
     #chatHeader{padding:10px;border-bottom:1px solid #444}
     #chatName{font-size:18px;margin-bottom:2px}
     #chatPath{font-size:12px;color:#aaa}
-    #summaryBox{margin-top:8px;font-size:12px;white-space:pre-wrap}
+    #summaryBox{margin-top:8px;font-size:12px}
+    #summaryText{white-space:pre-wrap}
     #messages{flex:1;overflow-y:auto;padding:10px;display:flex;flex-direction:column;gap:8px}
     .message{padding:8px;border-radius:4px;max-width:80%;white-space:pre-wrap}
     .user{background:#2f3b55;align-self:flex-end}
@@ -67,15 +68,19 @@
     <h3>Chats</h3>
     <div id='tabButtons'></div>
     <div id='fileList'></div>
+    <button id='clearArchiveBtn' style='display:none' onclick='clearArchive()'>Clear All</button>
   </div>
   <div id='chat'>
     <div id='chatHeader'>
       <div id='chatName'></div>
       <div id='chatPath'></div>
-      <div id='summaryBox'></div>
+      <details id='summaryBox' open>
+        <summary>Summary</summary>
+        <div id='summaryText'></div>
+      </details>
       <details id='sysBox'>
         <summary>System Prompt</summary>
-        <textarea id='sysPrompt' rows='4'></textarea>
+        <textarea id='sysPrompt' rows='4' onchange='updateSystem()'></textarea>
         <button onclick='updateSystem()'>Save</button>
       </details>
     </div>


### PR DESCRIPTION
## Summary
- persist latest summary in chat data
- add endpoint and button to clear archived chats
- make summary box collapsible
- auto-update system prompt on change

## Testing
- `python -m py_compile logic.py server.py cli.py`

------
https://chatgpt.com/codex/tasks/task_e_68631e668c48832991ab7517cdcd2774