### PR TITLE
Add server update button

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, BackgroundTasks
 from fastapi.responses import HTMLResponse
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
@@ -6,6 +6,8 @@ import os
 import json
 import shutil
 from datetime import datetime
+import subprocess
+import sys
 
 import logic
 
@@ -369,6 +371,16 @@ async def api_delete(data: dict):
 async def api_clear_archive():
     success = clear_archive()
     return {"success": success, "chats": list_chats()}
+
+
+@app.post('/api/update')
+async def api_update(background_tasks: BackgroundTasks):
+    def do_update():
+        subprocess.run([sys.executable, 'update.py'])
+        os.execl(sys.executable, sys.executable, 'server.py')
+
+    background_tasks.add_task(do_update)
+    return {"status": "updating"}
 
 
 @app.post('/api/message')

--- a/static/app.js
+++ b/static/app.js
@@ -127,6 +127,12 @@ async function clearArchive(){
   loadChats();
 }
 
+async function updateServer(){
+  if(!confirm('Update and restart server?')) return;
+  await fetch('/api/update',{method:'POST'});
+  setTimeout(()=>location.reload(),2000);
+}
+
 function showMessages(chat,res){
   const msgs=chat.messages;
   document.getElementById('chatName').textContent=chat.name||'';

--- a/static/index.html
+++ b/static/index.html
@@ -32,6 +32,7 @@
     .error{background:#552222;color:#ffbbbb;align-self:center}
     #sysBox{margin-top:10px}
     #sysPrompt{width:100%;background:#333;color:#eee;border:1px solid #555;margin-top:4px}
+    #commandBar{padding:5px;border-bottom:1px solid #444;background:#222;text-align:right}
     #input{display:flex;border-top:1px solid #444;position:sticky;bottom:0;background:#1e1e1e}
     #input textarea{flex:1;padding:5px;background:#333;color:#eee;border:1px solid #444}
     #input button{background:#444;color:#eee;border:1px solid #555;padding:5px 10px}
@@ -83,6 +84,9 @@
         <textarea id='sysPrompt' rows='4' onchange='updateSystem()'></textarea>
         <button onclick='updateSystem()'>Save</button>
       </details>
+      <div id='commandBar'>
+        <button onclick='updateServer()'>Update Server</button>
+      </div>
     </div>
     <div id='messages'></div>
     <div id='input'>


### PR DESCRIPTION
## Summary
- add `/api/update` endpoint that runs `update.py` and restarts the server
- call `update.py` from a new `updateServer()` function in the web UI
- add command bar with *Update Server* button

## Testing
- `python -m py_compile server.py update.py logic.py cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68632bba2f448329b36937468aa48933