### PR TITLE
Improve button styling and add new chat creation button

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -141,6 +141,13 @@ async function updateApiKey(){
   alert('API key updated');
 }
 
+async function newChat(){
+  const res=await fetch('/api/message',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({message:'/new'})});
+  const data=await res.json();
+  showMessages(data.chat,data.result);
+  hideSidebarOnMobile();
+}
+
 function showMessages(chat,res){
   const msgs=chat.messages;
   document.getElementById('chatName').textContent=chat.name||'';

--- a/static/index.html
+++ b/static/index.html
@@ -9,15 +9,22 @@
     #sidebar{width:250px;border-right:1px solid #444;overflow-y:auto;padding:10px;background:#2b2b2b;display:flex;flex-direction:column}
     #sidebar.show{transform:translateX(0)}
     #menuButton{display:none;position:fixed;top:10px;left:10px;z-index:11;background:#444;color:#eee;border:1px solid #555;font-size:20px;padding:5px 10px;cursor:pointer}
+
+    button{background:#444;color:#eee;border:1px solid #555;padding:5px 10px;border-radius:4px;cursor:pointer;transition:background .2s}
+    button:hover{background:#555}
+
+    #newChatBtn{margin-bottom:8px}
+
     #tabButtons{display:flex;margin-bottom:10px}
-    .tab{flex:1;padding:5px;background:#333;border:1px solid #444;color:#eee;cursor:pointer;text-align:center}
+    .tab{flex:1;padding:5px;background:#333;border:1px solid #444;color:#eee;cursor:pointer;text-align:center;border-radius:4px;transition:background .2s;margin-right:4px}
     .tab.active{background:#555}
     #fileList{display:flex;flex-direction:column;gap:6px}
     .chat-entry{cursor:pointer;color:#9cf;padding:2px;display:flex;align-items:center}
     .chat-entry:hover{background:#3a3a3a}
     .chat-name{font-size:14px;flex:1}
     .chat-file{font-size:12px;color:#aaa;margin-left:4px}
-    .chat-btn{margin-left:4px;background:#444;color:#eee;border:1px solid #666;font-size:11px;cursor:pointer}
+    .chat-btn{margin-left:4px;background:#444;color:#eee;border:1px solid #666;font-size:11px;cursor:pointer;border-radius:4px;transition:background .2s}
+    .chat-btn:hover{background:#555}
     #chat{flex:1;display:flex;flex-direction:column;height:100%}
     #chatHeader{padding:10px;border-bottom:1px solid #444}
     #chatName{font-size:18px;margin-bottom:2px}
@@ -34,7 +41,8 @@
     #sysPrompt{width:100%;background:#333;color:#eee;border:1px solid #555;margin-top:4px}
     #input{display:flex;border-top:1px solid #444;position:sticky;bottom:0;background:#1e1e1e}
     #input textarea{flex:1;padding:5px;background:#333;color:#eee;border:1px solid #444}
-    #input button{background:#444;color:#eee;border:1px solid #555;padding:5px 10px}
+    #input button{background:#444;color:#eee;border:1px solid #555;padding:5px 10px;border-radius:4px;transition:background .2s}
+    #input button:hover{background:#555}
 
     /* minimal scrollbars */
     #sidebar, #messages {
@@ -66,6 +74,7 @@
   <button id='menuButton' onclick='toggleSidebar()'>☰</button>
   <div id='sidebar'>
     <h3>Chats</h3>
+    <button id='newChatBtn' onclick='newChat()'>New Chat</button>
     <div id='tabButtons'></div>
     <div id='fileList'></div>
     <button id='clearArchiveBtn' style='display:none' onclick='clearArchive()'>Clear All</button>


### PR DESCRIPTION
## Summary
- add general styling for buttons and new chat button element
- include `newChat()` JS helper to start fresh chat session
- tweak chat list button styling and send button hover effects

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6864c709cafc8329a622920c5a06ad3f