### PR TITLE
Enable /update command in web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Run `python cli.py convert` to update old `.chat` files to version 1.0.
 - `/search <term>` find messages containing a term in the current chat
 - `/export <name>` save the chat as Markdown or text
 - `/update` update the application and restart
+- `/update` also works in the web UI command bar or chat input
 - `/model <name>` switch to a different model
 - `/model select` open a UI to choose a model
 - `/info` display the active filename, model and message count

--- a/server.py
+++ b/server.py
@@ -10,6 +10,7 @@ import shutil
 from datetime import datetime
 import subprocess
 import sys
+import threading
 from dotenv import load_dotenv, set_key
 
 # Load variables from .env first and fall back to system environment values
@@ -308,6 +309,17 @@ def handle_command(user_input):
         name = parts[1] if len(parts) > 1 else ''
         path = logic.export_chat(chat_data, name)
         return {"system": f"Exported to {path}"}
+    elif cmd == '/update':
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+
+        def do_update():
+            update_path = os.path.join(script_dir, 'update.py')
+            subprocess.run([sys.executable, update_path], cwd=script_dir)
+            server_path = os.path.join(script_dir, 'server.py')
+            os.execl(sys.executable, sys.executable, server_path)
+
+        threading.Thread(target=do_update, daemon=True).start()
+        return {"system": "Updating server..."}
     elif cmd == '/model':
         if len(parts) == 1:
             return {"system": f"Current model: {MODEL}"}


### PR DESCRIPTION
## Summary
- add `threading` to server
- allow `/update` command via chat interface
- document that `/update` works on the web UI

## Testing
- `python -m py_compile server.py update.py cli.py logic.py`

------
https://chatgpt.com/codex/tasks/task_e_6864d7c9a6648329b8afa0d2b0d8958d