### PR TITLE
Improve mobile layout with rounded UI

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -5,7 +5,10 @@ let currentTab='';
 
 // Show or hide the sidebar on small screens
 function toggleSidebar(){
-  document.getElementById('sidebar').classList.toggle('show');
+  const sb=document.getElementById('sidebar');
+  const btn=document.getElementById('menuButton');
+  sb.classList.toggle('show');
+  btn.classList.toggle('open',sb.classList.contains('show'));
 }
 
 

--- a/static/index.html
+++ b/static/index.html
@@ -7,9 +7,10 @@
   <title>GroqChat Web</title>
   <style>
     body{font-family:Arial,Helvetica,sans-serif;margin:0;display:flex;height:100vh;background:#1e1e1e;color:#eee;font-size:16px}
-    #sidebar{width:250px;border-right:1px solid #444;overflow-y:auto;padding:10px;background:#2b2b2b;display:flex;flex-direction:column}
+    #sidebar{width:250px;border-right:1px solid #444;overflow-y:auto;padding:10px;background:#2b2b2b;display:flex;flex-direction:column;border-radius:8px;overflow:hidden}
     #sidebar.show{transform:translateX(0)}
-    #menuButton{display:none;position:fixed;top:10px;left:10px;z-index:11;background:#444;color:#eee;border:1px solid #555;font-size:20px;padding:5px 10px;cursor:pointer}
+    #menuButton{display:none;position:fixed;top:10px;left:10px;z-index:11;background:#444;color:#eee;border:1px solid #555;font-size:20px;padding:5px 10px;cursor:pointer;border-radius:6px;transition:left .3s}
+    #menuButton.open{left:260px}
 
     button{background:#444;color:#eee;border:1px solid #555;padding:5px 10px;border-radius:4px;cursor:pointer;transition:background .2s}
     button:hover{background:#555}
@@ -26,7 +27,7 @@
     .chat-file{font-size:12px;color:#aaa;margin-left:4px}
     .chat-btn{margin-left:4px;background:#444;color:#eee;border:1px solid #666;font-size:11px;cursor:pointer;border-radius:4px;transition:background .2s}
     .chat-btn:hover{background:#555}
-    #chat{flex:1;display:flex;flex-direction:column;height:100%}
+    #chat{flex:1;display:flex;flex-direction:column;height:100%;border:1px solid #444;border-left:none;border-radius:8px;overflow:hidden}
     #chatHeader{padding:10px;border-bottom:1px solid #444}
     #chatName{font-size:18px;margin-bottom:2px}
     #chatPath{font-size:12px;color:#aaa}
@@ -65,8 +66,8 @@
 
     @media (max-width: 700px) {
       body{flex-direction:column;font-size:18px}
-      #sidebar{position:fixed;top:0;left:0;height:100vh;width:250px;border-bottom:none;transform:translateX(-260px);transition:transform .3s;z-index:10}
-      #chat{flex:1;margin-left:0}
+      #sidebar{position:fixed;top:0;left:0;height:100vh;width:250px;border-bottom:none;transform:translateX(-260px);transition:transform .3s;z-index:10;border-radius:8px}
+      #chat{flex:1;margin-left:0;margin-top:50px}
       #menuButton{display:block}
       .chat-name{font-size:16px}
       .chat-file{font-size:14px}


### PR DESCRIPTION
## Summary
- round side bar, chat panel and menu button
- shift chat panel down and move menu button aside on mobile
- adjust menu toggle JS to move the button

## Testing
- `python -m py_compile logic.py cli.py server.py update.py`

------
https://chatgpt.com/codex/tasks/task_e_6865429e4a9c8329912ba1215a69a447