### PR TITLE
Enable Add To Homescreen for GroqChat PWA

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,7 +1,7 @@
 """FastAPI server exposing the GroqChat web interface and REST API."""
 
 from fastapi import FastAPI, BackgroundTasks, Request, HTTPException
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 import os
@@ -464,6 +464,37 @@ async def api_message(data: dict):
     """Process a chat message or command."""
     res = process_message(data.get('message',''))
     return {"result": res, "chat": get_chat_state()}
+
+
+@app.get('/manifest.json')
+async def manifest():
+    """Return the web app manifest."""
+    data = {
+        "name": "GroqChat",
+        "short_name": "GroqChat",
+        "start_url": "/",
+        "display": "standalone",
+        "background_color": "#ffffff",
+        "theme_color": "#ffffff",
+        "icons": [
+            {
+                "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMAAAADACAIAAADdvvtQAAAB6klEQVR4nO3SQQ0AIRDAwOMcrH+zeKAPQjKjoI+umfng1H87gLcZiMRAJAYiMRCJgUgMRGIgEgORGIjEQCQGIjEQiYFIDERiIBIDkRiIxEAkBiIxEImBSAxEYiASA5EYiMRAJAYiMRCJgUgMRGIgEgORGIjEQCQGIjEQiYFIDERiIBIDkRiIxEAkBiIxEImBSAxEYiASA5EYiMRAJAYiMRCJgUgMRGIgEgORGIjEQCQGIjEQiYFIDERiIBIDkRiIxEAkBiIxEImBSAxEYiASA5EYiMRAJAYiMRCJgUgMRGIgEgORGIjEQCQGIjEQiYFIDERiIBIDkRiIxEAkBiIxEImBSAxEYiASA5EYiMRAJAYiMRCJgUgMRGIgEgORGIjEQCQGIjEQiYFIDERiIBIDkRiIxEAkBiIxEImBSAxEYiASA5EYiMRAJAYiMRCJgUgMRGIgEgORGIjEQCQGIjEQiYFIDERiIBIDkRiIxEAkBiIxEImBSAxEsgGOvgGzAbO4jAAAAABJRU5ErkJggg==",
+                "sizes": "192x192",
+                "type": "image/png"
+            }
+        ]
+    }
+    return Response(json.dumps(data), media_type="application/manifest+json")
+
+
+@app.get('/sw.js')
+async def service_worker():
+    """Serve a minimal service worker for installability."""
+    sw = """
+self.addEventListener('install', e => self.skipWaiting());
+self.addEventListener('activate', e => self.clients.claim());
+"""
+    return Response(sw, media_type="application/javascript")
 
 
 

--- a/static/index.html
+++ b/static/index.html
@@ -5,6 +5,10 @@
   <meta charset='utf-8'>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>GroqChat Web</title>
+  <link rel="manifest" href="/manifest.json">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="theme-color" content="#ffffff">
   <style>
     /* page gradient and nicer default font */
     body{font-family:'Segoe UI',Arial,Helvetica,sans-serif;margin:0;display:flex;height:100vh;background:linear-gradient(#1e1e1e,#151515);color:#eee;font-size:16px}
@@ -122,5 +126,10 @@
     </div>
   </div>
 <script src="/static/app.js"></script>
+<script>
+  if('serviceWorker' in navigator){
+    navigator.serviceWorker.register('/sw.js');
+  }
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- expose `/manifest.json` and `/sw.js` routes
- register a minimal service worker and PWA manifest
- update HTML head with manifest and mobile meta tags

## Testing
- `python3 -m py_compile server.py cli.py logic.py update.py`

------
https://chatgpt.com/codex/tasks/task_e_6865cb5ba3988329885a8245659cef5d