### PR TITLE
Improve sidebar scrolling behavior

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -13,7 +13,7 @@
     /* page gradient and nicer default font */
     body{font-family:'Segoe UI',Arial,Helvetica,sans-serif;margin:0;display:flex;height:100vh;background:linear-gradient(#1e1e1e,#151515);color:#eee;font-size:16px}
     /* subtle shadow around sidebar */
-    #sidebar{width:250px;height:100vh;border-right:1px solid #444;overflow-y:auto;padding:10px;background:#2b2b2b;display:flex;flex-direction:column;border-radius:12px;box-shadow:0 0 10px rgba(0,0,0,0.5)}
+    #sidebar{width:250px;height:100vh;border-right:1px solid #444;overflow:hidden;padding:10px;background:#2b2b2b;display:flex;flex-direction:column;border-radius:12px;box-shadow:0 0 10px rgba(0,0,0,0.5)}
     #sidebar.show{transform:translateX(0)}
     #menuButton{display:none;position:fixed;top:10px;left:10px;z-index:11;background:#444;color:#eee;border:1px solid #555;font-size:20px;padding:5px 10px;cursor:pointer;border-radius:10px;transition:left .3s}
     #menuButton.open{left:260px}
@@ -26,7 +26,7 @@
     #tabButtons{display:flex;margin-bottom:10px}
     .tab{flex:1;padding:5px;background:#333;border:1px solid #444;color:#eee;cursor:pointer;text-align:center;border-radius:8px;transition:background .2s;margin-right:4px}
     .tab.active{background:#555}
-    #fileList{flex:1;overflow-y:auto;display:flex;flex-direction:column;gap:6px}
+    #fileList{flex:1;overflow-y:auto;display:flex;flex-direction:column;gap:6px;resize:vertical;min-height:50px}
     .chat-entry{cursor:pointer;color:#9cf;padding:2px;display:flex;align-items:center}
     .chat-entry:hover{background:#3a3a3a}
     .chat-name{font-size:14px;flex:1}
@@ -58,17 +58,17 @@
     #commandBar{background:#2b2b2b;padding:10px;border-top:1px solid #444;display:flex;flex-direction:column;gap:6px}
 
     /* minimal scrollbars */
-    #sidebar, #messages {
+    #fileList, #messages {
       scrollbar-width: thin;
       scrollbar-color: #666 #333;
     }
-    #sidebar::-webkit-scrollbar, #messages::-webkit-scrollbar {
+    #fileList::-webkit-scrollbar, #messages::-webkit-scrollbar {
       width: 6px;
     }
-    #sidebar::-webkit-scrollbar-track, #messages::-webkit-scrollbar-track {
+    #fileList::-webkit-scrollbar-track, #messages::-webkit-scrollbar-track {
       background: #333;
     }
-    #sidebar::-webkit-scrollbar-thumb, #messages::-webkit-scrollbar-thumb {
+    #fileList::-webkit-scrollbar-thumb, #messages::-webkit-scrollbar-thumb {
       background-color: #666;
     }
 


### PR DESCRIPTION
## Summary
- make entire sidebar non-scrollable
- only scroll the chat list and allow it to be resized
- update scrollbar CSS for the chat list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865d082a5508329b2ff7934ad712d44