### PR TITLE
Fix command bar overflow

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -55,7 +55,7 @@
     #input button{background:#444;color:#eee;border:1px solid #555;padding:5px 10px;border-radius:8px;transition:background .2s}
     #input button:hover{background:#555}
 
-    #cmdBox{margin-top:auto;position:sticky;bottom:0;background:#2b2b2b}
+    #cmdBox{margin-top:auto;background:#2b2b2b}
     #commandBar{background:#2b2b2b;padding:10px;border-top:1px solid #444;display:flex;flex-direction:column;gap:6px}
 
     /* minimal scrollbars */


### PR DESCRIPTION
## Summary
- remove sticky positioning from command bar container so it can expand within the sidebar

## Testing
- `python -m py_compile server.py cli.py logic.py update.py`

------
https://chatgpt.com/codex/tasks/task_e_6865e0b3ded88329b81936a7bcac4a18