### PR TITLE
Update sidebar layout ratio

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -55,7 +55,8 @@
     #input button{background:#444;color:#eee;border:1px solid #555;padding:5px 10px;border-radius:8px;transition:background .2s}
     #input button:hover{background:#555}
 
-    #cmdBox{margin-top:auto;background:#2b2b2b}
+    #chatSection{flex:0 0 75%;display:flex;flex-direction:column;overflow-y:auto}
+    #cmdBox{flex:0 0 25%;background:#2b2b2b;overflow-y:auto}
     #commandBar{background:#2b2b2b;padding:10px;border-top:1px solid #444;display:flex;flex-direction:column;gap:6px}
 
     /* minimal scrollbars */
@@ -88,11 +89,13 @@
   <button id='menuButton' onclick='toggleSidebar()'>☰</button>
   <!-- Sidebar with chat list and controls -->
   <div id='sidebar'>
-    <h3>Chats</h3>
-    <button id='newChatBtn' onclick='newChat()'>New Chat</button>
-    <div id='tabButtons'></div>
-    <div id='fileList'></div>
-    <button id='clearArchiveBtn' style='display:none' onclick='clearArchive()'>Clear All</button>
+    <div id='chatSection'>
+      <h3>Chats</h3>
+      <button id='newChatBtn' onclick='newChat()'>New Chat</button>
+      <div id='tabButtons'></div>
+      <div id='fileList'></div>
+      <button id='clearArchiveBtn' style='display:none' onclick='clearArchive()'>Clear All</button>
+    </div>
     <!-- Command inputs for API key and server update -->
     <details id='cmdBox'>
       <summary>Commands</summary>


### PR DESCRIPTION
## Summary
- allocate 75% of sidebar height to chat controls
- reserve remaining 25% for command bar

## Testing
- `python -m py_compile cli.py logic.py server.py update.py`


------
https://chatgpt.com/codex/tasks/task_e_6865e68ff6f083299446ae8b7b7e3d7b