### PR TITLE
Enable scrolling sidebar

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -12,7 +12,7 @@
     <style>
       :root{--sidebar-width:min(250px,50vw);} /* variable to cap sidebar width */
       /* page gradient and nicer default font */
-      body{font-family:'Segoe UI',Arial,Helvetica,sans-serif;margin:0;display:flex;height:100vh;background:linear-gradient(#1e1e1e,#151515);color:#eee;font-size:16px}
+      body{font-family:'Segoe UI',Arial,Helvetica,sans-serif;margin:0;display:flex;height:100vh;overflow:hidden;background:linear-gradient(#1e1e1e,#151515);color:#eee;font-size:16px}
     /* subtle shadow around sidebar */
     #sidebar{width:var(--sidebar-width);height:100vh;border-right:1px solid #444;overflow-y:auto;padding:10px;background:#2b2b2b;display:flex;flex-direction:column;border-radius:12px;box-shadow:0 0 10px rgba(0,0,0,0.5)}
     #sidebar.show{transform:translateX(0)}
@@ -27,7 +27,7 @@
     #tabButtons{display:flex;margin-bottom:10px}
     .tab{flex:1;padding:5px;background:#333;border:1px solid #444;color:#eee;cursor:pointer;text-align:center;border-radius:8px;transition:background .2s;margin-right:4px}
     .tab.active{background:#555}
-    #fileList{flex:1;overflow-y:auto;display:flex;flex-direction:column;gap:6px;resize:vertical;min-height:50px;max-height:75%}
+    #fileList{flex:1;display:flex;flex-direction:column;gap:6px}
     .chat-entry{cursor:pointer;color:#9cf;padding:2px;display:flex;align-items:center}
     .chat-entry:hover{background:#3a3a3a}
     .chat-name{font-size:14px;flex:1}
@@ -55,8 +55,8 @@
     #input button{background:#444;color:#eee;border:1px solid #555;padding:5px 10px;border-radius:8px;transition:background .2s}
     #input button:hover{background:#555}
 
-    #chatSection{flex:0 0 75%;display:flex;flex-direction:column;overflow-y:auto}
-    #cmdBox{flex:0 0 25%;background:#2b2b2b;overflow-y:auto}
+    #chatSection{flex:0 0 75%;display:flex;flex-direction:column}
+    #cmdBox{flex:0 0 25%;background:#2b2b2b}
     #commandBar{background:#2b2b2b;padding:10px;border-top:1px solid #444;display:flex;flex-direction:column;gap:6px}
 
     /* minimal scrollbars */


### PR DESCRIPTION
## Summary
- keep page from scrolling and only scroll the sidebar
- simplify sidebar layout so the entire column scrolls

## Testing
- `python -m py_compile cli.py server.py logic.py update.py`

------
https://chatgpt.com/codex/tasks/task_e_6866002496ac8329b30dfa72770876c7