### PR TITLE
Fix layout: sticky header and footer

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -36,7 +36,7 @@
     .chat-btn:hover{background:#555}
     /* match shadow on main chat area */
     #chat{flex:1;display:flex;flex-direction:column;height:100%;border:1px solid #444;border-left:none;border-radius:12px;overflow:hidden;box-shadow:0 0 10px rgba(0,0,0,0.5)}
-    #chatHeader{padding:10px;border-bottom:1px solid #444}
+    #chatHeader{padding:10px;border-bottom:1px solid #444;position:sticky;top:0;background:#1e1e1e;z-index:1}
     #chatName{font-size:18px;margin-bottom:2px}
     #chatPath{font-size:12px;color:#aaa}
     #summaryBox{margin-top:8px;font-size:12px}
@@ -50,7 +50,7 @@
     .error{background:#552222;color:#ffbbbb;align-self:center}
     #sysBox{margin-top:10px}
     #sysPrompt{width:100%;background:#333;color:#eee;border:1px solid #555;margin-top:4px}
-    #input{display:flex;border-top:1px solid #444;position:sticky;bottom:0;background:#1e1e1e}
+    #input{display:flex;border-top:1px solid #444;position:sticky;bottom:0;background:#1e1e1e;z-index:1}
     #input textarea{flex:1;padding:5px;background:#333;color:#eee;border:1px solid #444;border-radius:10px;margin-right:5px;max-width:75%}
     #input button{background:#444;color:#eee;border:1px solid #555;padding:5px 10px;border-radius:8px;transition:background .2s}
     #input button:hover{background:#555}


### PR DESCRIPTION
## Summary
- keep chat header pinned to the top
- keep message input pinned to the bottom

## Testing
- `python -m py_compile logic.py server.py cli.py update.py`

------
https://chatgpt.com/codex/tasks/task_e_68660a345e248329b7860d88e0495e55