### PR TITLE
Enable PWA fullscreen mode on Android

### DIFF
--- a/server.py
+++ b/server.py
@@ -498,7 +498,8 @@ async def manifest():
         "name": "GroqChat",
         "short_name": "GroqChat",
         "start_url": "/",
-        "display": "standalone",
+        "display": "fullscreen",
+        "display_override": ["fullscreen", "standalone"],
         "background_color": "#ffffff",
         "theme_color": "#ffffff",
         "icons": [


### PR DESCRIPTION
## Summary
- update the PWA manifest served from `server.py` to request fullscreen display

## Testing
- `python -m py_compile server.py cli.py logic.py update.py`

------
https://chatgpt.com/codex/tasks/task_e_68669044f7108329868164670738f082